### PR TITLE
move _.functions over to willsCheatMenu

### DIFF
--- a/willsCheatMenu/src/hacks/inventory.ts
+++ b/willsCheatMenu/src/hacks/inventory.ts
@@ -4,22 +4,22 @@ import { gameData, VERY_LARGE_NUMBER, savePlayer } from "../utils/util";
 import { Item } from "../../../typings/item";
 import { BackpackItemType } from "../../../typings/backpack";
 import { prodigy, game } from "../utils/util";
-const itemify = (item: Item[]) =>
+const itemify = (item: Item[], amount: number) =>
 	item.map(x => ({
 		ID: x.ID,
-		N:  VERY_LARGE_NUMBER,
+		N:  amount,
 	}));
 
 const inventoryHack = (
 	name: string,
 	id: BackpackItemType,
-	lowercase: string = name.toLowerCase()
+	amount: number = 1
 ) => {
 	new Hack(category.inventory, `Obtain All ${name}`).setClick(async () => {
-		_.player.backpack.data[id] = itemify(gameData[id]);
+		_.player.backpack.data[id] = itemify(gameData[id], amount);
 		await Toast.fire(
 			`${name} Added!`,
-			`All ${lowercase} have been added to your inventory!`,
+			`All ${name.toLowerCase()} have been added to your inventory!`,
 			"success"
 		);
 		savePlayer();
@@ -27,12 +27,12 @@ const inventoryHack = (
 };
 inventoryHack("Boots", "boots");
 inventoryHack("Buddies", "follow");
-inventoryHack("Fossils", "fossil");
+inventoryHack("Fossils", "fossil", VERY_LARGE_NUMBER);
 inventoryHack("Hats", "hat");
-inventoryHack("Items", "item");
-inventoryHack("Key Items", "key");
-inventoryHack("Math Town Frames", "mathTownFrame");
-inventoryHack("Math Town Interiors", "mathTownInterior");
+inventoryHack("Items", "item", VERY_LARGE_NUMBER);
+inventoryHack("Key Items", "key", VERY_LARGE_NUMBER);
+inventoryHack("Math Town Frames", "mathTownFrame", VERY_LARGE_NUMBER);
+inventoryHack("Math Town Interiors", "mathTownInterior", VERY_LARGE_NUMBER);
 inventoryHack("Mounts", "mount");
 inventoryHack("Outfits", "outfit");
 inventoryHack("Relics", "relic");

--- a/willsCheatMenu/src/hacks/misc.ts
+++ b/willsCheatMenu/src/hacks/misc.ts
@@ -3,7 +3,20 @@ import { Hack, category, Toggler } from "../index";
 import { VERY_LARGE_NUMBER, gameData, pickRandom } from "../utils/util";
 import { prodigy, game } from "../utils/util";
 new Hack(category.misc, "Skip Tutorial").setClick(async () => {
-	_.functions.completeTutorial();
+	const setQuest = (t: string, i: number, n?: unknown, e?: unknown) => {
+		_.instance.prodigy.world.getZone(t).testQuest(i, n, e);
+		try {
+			_.instance.game.state.states.TileScreen.process();
+		} catch {}
+	};
+
+	setQuest("house", 2);
+	setQuest("academy", 2);
+	_.player.state.set("tutorial-0", 4);
+	_.player.backpack.addKeyItem(13, 0);
+	_.player.tutorial.data.menus[14] = [1]
+	_.instance.prodigy.open.map(true, []);
+	_.player.onTutorialComplete();
 });
 /*
 new Hack(category.misc, "Disable Timeout Dialog").setClick(async () => {


### PR DESCRIPTION
Move _.functions over to WCM, not a necessary change.
Up to Will to decide if this should be merged or not. If not, deny the related PR in Redirector.

[Related](https://github.com/Prodigy-Hacking/Redirector/pull/3)

Intent is to clean up some things, make it easier to add new things to WCM.
It seems a little strange to define stuff like getAllPets in Redirector, and makes fixing stuff in _.functions annoying.