### PR TITLE
Clean up parse jwt function

### DIFF
--- a/hacks/scriptBasedHacks/ArenaPoints.js
+++ b/hacks/scriptBasedHacks/ArenaPoints.js
@@ -1,10 +1,7 @@
 function parseJwt(token) {
-    var base64Url = token.split('.')[1];
-    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
-    }).join(''));
-    return JSON.parse(jsonPayload)
+    var base64 = token.split(".")[1];
+    var jsonPayload = atob(base64);
+    return JSON.parse(jsonPayload);
 };
 
 let userID = parseJwt(localStorage.JWT_TOKEN).content.userID

--- a/hacks/scriptBasedHacks/beatDarkTower.js
+++ b/hacks/scriptBasedHacks/beatDarkTower.js
@@ -1,10 +1,6 @@
-function parseJwt (token) {
-    var base64Url = token.split('.')[1];
-    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-
+function parseJwt(token) {
+    var base64 = token.split(".")[1];
+    var jsonPayload = atob(base64);
     return JSON.parse(jsonPayload);
 };
 let userID = parseJwt(localStorage.JWT_TOKEN).content.userID

--- a/hacks/scriptBasedHacks/getAllPets.js
+++ b/hacks/scriptBasedHacks/getAllPets.js
@@ -1,10 +1,6 @@
 function parseJwt(token) {
-    var base64Url = token.split('.')[1];
-    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-
+    var base64 = token.split(".")[1];
+    var jsonPayload = atob(base64);
     return JSON.parse(jsonPayload);
 };
 

--- a/hacks/scriptBasedHacks/gold.js
+++ b/hacks/scriptBasedHacks/gold.js
@@ -1,10 +1,6 @@
 function parseJwt(token) {
-    var base64Url = token.split('.')[1];
-    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-
+    var base64 = token.split(".")[1];
+    var jsonPayload = atob(base64);
     return JSON.parse(jsonPayload);
 };
 

--- a/hacks/scriptBasedHacks/level100.js
+++ b/hacks/scriptBasedHacks/level100.js
@@ -1,10 +1,6 @@
-function parseJwt (token) {
-    var base64Url = token.split('.')[1];
-    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(''));
-
+function parseJwt(token) {
+    var base64 = token.split(".")[1];
+    var jsonPayload = atob(base64);
     return JSON.parse(jsonPayload);
 };
 let userID = parseJwt(localStorage.JWT_TOKEN).content.userID


### PR DESCRIPTION
## Description
For all script based hacks I cleaned up the parse jwt function.

Making it this:
```js
function parseJwt(token) {
    var base64 = token.split(".")[1];
    var jsonPayload = atob(base64);
    return JSON.parse(jsonPayload);
};
```
instead of this:
```js
function parseJwt(token) {
    var base64Url = token.split('.')[1];
    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
    var jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
    }).join(''));
    return JSON.parse(jsonPayload)
};
```