### PR TITLE
replace old YouTube link with new YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 		•
 		<a href="https://github.com/Prodigy-Hacking/ProdigyMathGameHacking/wiki/How-to-install-hacks">Installation</a>
 		•
-		<a href="https://www.youtube.com/channel/UChIRMY6SdQrcADVscWTVv9A">Youtube</a>
+		<a href="https://www.youtube.com/channel/UCr6WNMDW-bytEVGL1Vna7Lw">Youtube</a>
 	</strong>
 </p>
 <p align="center">


### PR DESCRIPTION
## Description

replace old, terminated YouTube link with new YouTube: link https://www.youtube.com/channel/UCr6WNMDW-bytEVGL1Vna7Lw

edit: also, on the [extension](https://chrome.google.com/webstore/detail/prodigy-hacking-extension/gjabpajagbgoifbkflgojeojmnlmioea?hl=en-US), you should also replace the old, removed video with the [new video](https://youtu.be/OhfHNatEtw4), 
